### PR TITLE
[refactor] Gmail smtp > Mailgun api 이메일 전송 서비스 로직 변경

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
     implementation("org.springframework.ai:spring-ai-starter-model-openai")
     implementation("org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini")
-
+    implementation("com.mailgun:mailgun-java:1.0.1")
 
     implementation("org.springframework.boot:spring-boot-starter-webflux")
 

--- a/backend/src/main/java/com/backend/api/user/service/EmailService.kt
+++ b/backend/src/main/java/com/backend/api/user/service/EmailService.kt
@@ -8,32 +8,78 @@ import com.backend.domain.userPenalty.entity.UserPenalty
 import com.backend.global.exception.ErrorCode
 import com.backend.global.exception.ErrorException
 import org.slf4j.LoggerFactory
-import org.springframework.mail.SimpleMailMessage
-import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.scheduling.annotation.Async
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.web.reactive.function.BodyInserters
+import org.springframework.web.reactive.function.client.WebClient
 import java.security.SecureRandom
 import java.time.LocalDateTime
+import java.util.*
 
 @Service
 class EmailService(
-    private val mailSender: JavaMailSender,
-    private val verificationCodeRepository: VerificationCodeRepository
+    private val verificationCodeRepository: VerificationCodeRepository,
+
+    @Value("\${mailgun.api-key}")
+    private val mailgunApiKey: String,
+
+    @Value("\${mailgun.domain}")
+    private val mgDomain: String,
+
+    @Value("\${mailgun.from}")
+    private val fromEmail: String
 ) {
 
-    companion object {
-        private val log = LoggerFactory.getLogger(EmailService::class.java)
+    private val log = LoggerFactory.getLogger(EmailService::class.java)
 
-        private const val CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-        private const val CODE_LENGTH = 6
+    private val CHAR_SET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    private val CODE_LENGTH = 6
+
+    private val mailgunClient: WebClient = WebClient.builder()
+        .baseUrl("https://api.mailgun.net/v3/$mgDomain")
+        .defaultHeaders {
+            val auth = "api:$mailgunApiKey"
+            val encoded = Base64.getEncoder().encodeToString(auth.toByteArray())
+            it.set("Authorization", "Basic $encoded")
+        }
+        .build()
+
+    // 메일 발송
+    private fun sendEmail(toEmail: String, subject: String, content: String) {
+        try {
+            val form = LinkedMultiValueMap<String, String>().apply {
+                add("from", fromEmail)
+                add("to", toEmail)
+                add("subject", subject)
+                add("text", content)
+            }
+
+            val response = mailgunClient.post()
+                .uri("/messages")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(form))
+                .retrieve()
+                .bodyToMono(String::class.java)
+                .block()
+
+            log.info("메일 전송 완료: {} | 응답={}", toEmail, response)
+
+        } catch (e: Exception) {
+            log.error("메일 전송 실패: {}", e.message)
+            throw ErrorException(ErrorCode.EMAIL_SEND_FAILED)
+        }
     }
 
-    // 인증코드 생성 + 이메일 발송
+
+    // 인증코드 생성 및 발송
     @Transactional
     fun createAndSendVerificationCode(email: String) {
-        verificationCodeRepository.findByEmail(email)
-            ?.let { verificationCodeRepository.delete(it) }
+        verificationCodeRepository.findByEmail(email)?.let {
+            verificationCodeRepository.delete(it)
+        }
 
         val code = generateVerificationCode()
 
@@ -46,36 +92,19 @@ class EmailService(
 
         verificationCodeRepository.save(verification)
 
-        sendVerificationMailAsync(email, code)
+        val content = """
+            안녕하세요. Dev-Station 입니다.
+
+            아래 인증 코드를 입력해 주세요.
+
+            인증코드: $code
+            (유효시간 5분)
+        """.trimIndent()
+
+        sendEmail(email, "[Dev-Station] 이메일 인증 코드", content)
     }
 
-    // 인증 메일 비동기 발송
-    @Async("mailExecutor")
-    fun sendVerificationMailAsync(email: String, code: String) {
-        try {
-            val message = SimpleMailMessage().apply {
-                setTo(email)
-                subject = "[Dev-Station] 이메일 인증 코드"
-                text =
-                    """
-                    안녕하세요. Dev-Station 입니다.
 
-                    아래 인증 코드를 입력해 주세요.
-                    인증코드: $code
-
-                    본 코드는 5분간 유효합니다.
-                    """.trimIndent()
-            }
-
-            mailSender.send(message)
-            log.info("[이메일 인증] 인증코드 전송 완료: {}", email)
-        } catch (e: Exception) {
-            log.error("이메일 인증코드 전송 실패: {}", e.message, e)
-            throw ErrorException(ErrorCode.EMAIL_SEND_FAILED)
-        }
-    }
-
-    // 인증코드 생성
     private fun generateVerificationCode(): String {
         val random = SecureRandom()
         return buildString(CODE_LENGTH) {
@@ -85,18 +114,17 @@ class EmailService(
         }
     }
 
+
     // 인증코드 검증
     fun verifyCode(email: String, code: String) {
         val verification = verificationCodeRepository.findByEmail(email)
             ?: throw ErrorException(ErrorCode.INVALID_VERIFICATION_CODE)
 
-        if (verification.isExpired()) {
+        if (verification.isExpired())
             throw ErrorException(ErrorCode.EXPIRED_VERIFICATION_CODE)
-        }
 
-        if (verification.code != code) {
+        if (verification.code != code)
             throw ErrorException(ErrorCode.INVALID_VERIFICATION_CODE)
-        }
 
         verification.markAsVerified()
         verificationCodeRepository.save(verification)
@@ -104,126 +132,83 @@ class EmailService(
         log.info("[이메일 인증] 인증 성공: {}", email)
     }
 
-    // 이메일 인증 여부 조회
     fun isVerified(email: String): Boolean =
         verificationCodeRepository.findByEmail(email)?.verified ?: false
 
-    // 회원가입 환영 이메일
-    @Async("mailExecutor")
+
+    // 회원 가입 환영 메일
     fun sendWelcomeMail(user: User) {
-        try {
-            val message = SimpleMailMessage().apply {
-                setTo(user.email)
-                subject = "[Dev-Station] 회원가입을 환영합니다!"
-                text =
-                    """
-                    안녕하세요, ${user.name}님 👋
+        val content = """
+            안녕하세요, ${user.name}님 👋
 
-                    Dev-Station에 가입해 주셔서 감사합니다.
-                    다양한 기능을 이용하실 수 있습니다.
+            Dev-Station 가입을 환영합니다!
+        """.trimIndent()
 
-                    앞으로 좋은 서비스로 보답하겠습니다!
-                    """.trimIndent()
-            }
-
-            mailSender.send(message)
-            log.info("[회원가입 메일] 환영 메일 전송 완료: {}", user.email)
-        } catch (e: Exception) {
-            log.error("회원가입 환영 메일 전송 실패: {}", e.message, e)
-        }
+        sendEmail(user.email, "[Dev-Station] 회원가입을 환영합니다!", content)
     }
 
-    // 계정 상태 변경 메일
-    @Async("mailExecutor")
+
+    //계정 상태 변경 메일
     fun sendStatusChangeMail(user: User, penalty: UserPenalty?) {
 
-        val status = user.accountStatus
-
-        // 정지 / 영구정지 상태는 penalty 필수
-        if ((status == AccountStatus.SUSPENDED || status == AccountStatus.BANNED) && penalty == null) {
-            log.error("패널티가 있어야 하는 상태인데 penalty=null | user={}", user.email)
-            return
-        }
-
-        val p = penalty // 가독성을 위해 별도 변수화
-
-        // 이메일 제목 + 내용 처리
-        val (subject, content) = when (status) {
+        val (subject, content) = when (user.accountStatus) {
 
             AccountStatus.SUSPENDED -> {
-                val reason = p?.reason ?: "사유 정보 없음"
-                val endAt = p?.endAt ?: "미정"
+                val reason = penalty?.reason ?: "사유 정보 없음"
+                val endAt = penalty?.endAt ?: "미정"
 
                 "[Dev-Station] 계정 일시정지 안내" to """
-                안녕하세요, ${user.name}님.
+                    안녕하세요, ${user.name}님.
 
-                회원님의 계정이 일시정지되었습니다.
-                사유: $reason
-                종료일: $endAt
+                    회원님의 계정이 일시정지되었습니다.
+                    사유: $reason
+                    종료일: $endAt
                 """.trimIndent()
             }
 
             AccountStatus.BANNED -> {
-                val reason = p?.reason ?: "사유 정보 없음"
+                val reason = penalty?.reason ?: "사유 정보 없음"
+                "[Dev-Station] 계정 영구정지 안내" to """
+                    안녕하세요, ${user.name}님.
 
-                "[Dev-Station] 계정 영구 정지 안내" to """
-                안녕하세요, ${user.name}님.
-
-                회원님의 계정이 영구 정지되었습니다.
-                사유: $reason
+                    회원님의 계정이 영구 정지되었습니다.
+                    사유: $reason
                 """.trimIndent()
             }
 
             AccountStatus.ACTIVE -> {
                 "[Dev-Station] 계정 복구 안내" to """
-                안녕하세요, ${user.name}님.
+                    안녕하세요, ${user.name}님.
 
-                회원님의 계정이 정상으로 복구되었습니다.
+                    회원님의 계정이 정상으로 복구되었습니다.
                 """.trimIndent()
             }
 
             AccountStatus.DEACTIVATED -> {
                 "[Dev-Station] 탈퇴 완료 안내" to """
-                안녕하세요, ${user.name}님.
+                    안녕하세요, ${user.name}님.
 
-                회원님의 계정 탈퇴 처리가 완료되었습니다.
+                    회원님의 계정 탈퇴 처리가 완료되었습니다.
                 """.trimIndent()
             }
         }
 
-        // 이메일 발송
-        val message = SimpleMailMessage().apply {
-            setTo(user.email)
-            this.subject = subject
-            text = content
-        }
-
-        mailSender.send(message)
+        sendEmail(user.email, subject, content)
     }
+
 
     // 임시 비밀번호 발송
     fun sendNewPassword(email: String, newPassword: String) {
-        try {
-            val message = SimpleMailMessage().apply {
-                setTo(email)
-                subject = "[Dev-Station] 임시 비밀번호 안내"
-                text =
-                    """
-                    안녕하세요. Dev-Station 입니다.
 
-                    요청하신 임시 비밀번호를 발급해드립니다.
-                    로그인 후 반드시 새 비밀번호로 변경해주세요.
+        val content = """
+            안녕하세요. Dev-Station 입니다.
 
-                    임시 비밀번호: $newPassword
-                    """.trimIndent()
-            }
+            요청하신 임시 비밀번호를 발급해드립니다.
+            로그인 후 반드시 새 비밀번호로 변경해주세요.
 
-            mailSender.send(message)
-            log.info("[비밀번호 재설정] 임시 비밀번호 전송 완료: {}", email)
+            임시 비밀번호: $newPassword
+        """.trimIndent()
 
-        } catch (e: Exception) {
-            log.error("임시 비밀번호 전송 실패: {}", e.message, e)
-            throw ErrorException(ErrorCode.EMAIL_SEND_FAILED)
-        }
+        sendEmail(email, "[Dev-Station] 임시 비밀번호 안내", content)
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
     active: prod
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${DB_JDBC_URL}
@@ -35,34 +36,20 @@ spring:
       ai:
         gemini:
           project-id: ${GOOGLE_API_KEY}
-          location : asia-northeast3
+          location: asia-northeast3
           chat:
             options:
               model: "vertex--pro-vision"
-
-  mail:
-    host: smtp.gmail.com
-    port: 587
-    username: ${EMAIL_ID}
-    password: ${EMAIL_PW}
-    properties:
-      mail:
-        smtp:
-          auth: true
-          starttls:
-            enable: true
-            required: true
-          connectiontimeout: 10000
-          timeout: 10000
-          writetimeout: 10000
-          ssl:
-            trust: smtp.gmail.com
-
 
   data:
     redis:
       host: localhost
       port: 6379
+
+mailgun:
+  api-key: ${MAILGUN_API_KEY}
+  domain: ${MAILGUN_DOMAIN}
+  from: ${MAILGUN_FROM}
 
 logging:
   level:


### PR DESCRIPTION
## 📝 작업 개요
- 원래는 sendgrid 서비스를 사용하려고 했으나 신규 계정이 아시아 국가이면 차단된다는 슬픈 사실...(아시아 국가에서 생성된 계정이 스팸이나 홍보에 너무 많이 쓰여서 그렇다고 하네요 aws ses도 동일한 문제)
 그래서 다른 서비스를 찾아보던 중 mailgun 서비스가 가능하다고 하여서 교체 하였습니다. 
 - aws ses가 3번째 요청 대기중인데 안될 가능성이 있어서 우선 mailgun을 활용하는 방안으로 바꿨습니다.

## 🔗 관련 이슈
- Close #38 

## 🔍 작업 내용
- Mailgun WebClient 기반 이메일 발송 서비스 신규 구현
- 이메일 인증 코드 발송 로직 Mailgun 버전으로 교체
- [x] 발송량 제한이 있어서 BaseInitData에서 signup 을 통한 가입을 없앤 뒤 머지 해야 함

## ✅ 체크리스트
- [x] 코드에 오류가 없음
- [ ] 테스트 코드 작성/수행 완료
- [x] 팀 내 코드 스타일 가이드 준수
- [x] 이슈 연결 여부
      
